### PR TITLE
Support POST requests proxying

### DIFF
--- a/src/Request/WrappedRequest.php
+++ b/src/Request/WrappedRequest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace lav45\MockServer\Request;
+
+use Amp\ByteStream\BufferException;
+use Amp\ByteStream\StreamException;
+use Amp\Http\Server\ClientException;
+use Amp\Http\Server\Request;
+use RuntimeException;
+
+/**
+ * @mixin Request
+ */
+class WrappedRequest
+{
+    /** @var string */
+    protected const ATTRIBUTE_NAME = __CLASS__;
+    /** @var Request */
+    protected Request $request;
+    /** @var WrappedRequestBody|null */
+    protected ?WrappedRequestBody $body = null;
+
+    /**
+     * @param Request $request
+     * @return static
+     */
+    public static function getInstance(Request $request): static
+    {
+        if ($request->hasAttribute(self::ATTRIBUTE_NAME) === false) {
+            $request->setAttribute(self::ATTRIBUTE_NAME, new self($request));
+        }
+        return $request->getAttribute(self::ATTRIBUTE_NAME);
+    }
+
+    /**
+     * @param Request $request
+     */
+    protected function __construct(Request $request)
+    {
+        $this->request = $request;
+    }
+
+    /**
+     * @param string $name
+     * @param array $args
+     * @return false|mixed
+     */
+    public function __call(string $name, array $args)
+    {
+        if (method_exists($this->request, $name)) {
+            return call_user_func_array([$this->request, $name], $args);
+        }
+        throw new RuntimeException('Calling unknown method: ' . get_class($this) . "::$name()");
+    }
+
+    /**
+     * @return WrappedRequestBody
+     */
+    public function getBody(): WrappedRequestBody
+    {
+        return $this->body ??= new WrappedRequestBody($this->request->getBody());
+    }
+
+    /**
+     * @return Request
+     * @throws BufferException
+     * @throws StreamException
+     * @throws ClientException
+     */
+    public function getRequest(): Request
+    {
+        $clone = clone $this->request;
+        $clone->setBody($this->getBody()->buffer());
+        return $clone;
+    }
+}

--- a/src/Request/WrappedRequestBody.php
+++ b/src/Request/WrappedRequestBody.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace lav45\MockServer\Request;
+
+use Amp\ByteStream\BufferException;
+use Amp\ByteStream\StreamException;
+use Amp\Cancellation;
+use Amp\Http\Server\ClientException;
+use Amp\Http\Server\RequestBody;
+use RuntimeException;
+use const PHP_INT_MAX;
+
+/**
+ * @mixin RequestBody
+ */
+class WrappedRequestBody
+{
+    /** @var RequestBody */
+    protected RequestBody $body;
+    /** @var string|null */
+    protected ?string $buffer = null;
+
+    /**
+     * @param RequestBody $requestBody
+     */
+    public function __construct(RequestBody $requestBody)
+    {
+        $this->body = $requestBody;
+    }
+
+    /**
+     * @param string $name
+     * @param array $args
+     * @return false|mixed
+     */
+    public function __call(string $name, array $args)
+    {
+        if (method_exists($this->body, $name)) {
+            return call_user_func_array([$this->body, $name], $args);
+        }
+        throw new RuntimeException('Calling unknown method: ' . get_class($this) . "::$name()");
+    }
+
+    /**
+     * @param Cancellation|null $cancellation
+     * @param int $limit
+     * @return string
+     * @throws BufferException
+     * @throws StreamException
+     * @throws ClientException
+     */
+    public function buffer(?Cancellation $cancellation = null, int $limit = PHP_INT_MAX): string
+    {
+        return $this->buffer ??= $this->body->buffer($cancellation, $limit);
+    }
+
+    /**
+     * @param Cancellation|null $cancellation
+     * @return string|null
+     * @throws StreamException
+     * @throws ClientException
+     */
+    public function read(?Cancellation $cancellation = null): ?string
+    {
+        return $this->buffer ??= $this->body->read($cancellation);
+    }
+}

--- a/src/RequestHandler.php
+++ b/src/RequestHandler.php
@@ -22,7 +22,7 @@ class RequestHandler implements \Amp\Http\Server\RequestHandler
      */
     public function __construct(
         private readonly MockResponse $response,
-        private readonly EnvParser    $parser,
+        private readonly EnvParser    $parser
     )
     {
     }

--- a/src/RequestHandler/BaseRequestHandler.php
+++ b/src/RequestHandler/BaseRequestHandler.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace lav45\MockServer\RequestHandler;
+
+use Amp\Http\Server\Request;
+use Amp\Http\Server\RequestHandler;
+use Amp\Http\Server\Response;
+use lav45\MockServer\Request\WrappedRequest;
+
+abstract class BaseRequestHandler implements RequestHandler, WrappedRequestHandlerInterface
+{
+    public function handleRequest(Request $request): Response
+    {
+        $wrappedRequest = WrappedRequest::getInstance($request);
+        return $this->handleWrappedRequest($wrappedRequest);
+    }
+}

--- a/src/RequestHandler/ContentHandler.php
+++ b/src/RequestHandler/ContentHandler.php
@@ -2,17 +2,16 @@
 
 namespace lav45\MockServer\RequestHandler;
 
-use Amp\Http\Server\Request;
-use Amp\Http\Server\RequestHandler;
 use Amp\Http\Server\Response;
 use lav45\MockServer\EnvParser;
 use lav45\MockServer\Mock\Response\Content;
+use lav45\MockServer\Request\WrappedRequest;
 
 /**
  * Class ContentHandler
  * @package lav45\MockServer\RequestHandler
  */
-class ContentHandler implements RequestHandler
+class ContentHandler extends BaseRequestHandler
 {
     /**
      * @param Content $content
@@ -26,11 +25,11 @@ class ContentHandler implements RequestHandler
     }
 
     /**
-     * @param Request $request
+     * @param WrappedRequest $request
      * @return Response
      * @throws \JsonException
      */
-    public function handleRequest(Request $request): Response
+    public function handleWrappedRequest(WrappedRequest $request): Response
     {
         if ($this->content->getType() === Content::TYPE_JSON) {
             $json = $this->content->getJson();

--- a/src/RequestHandler/DataHandler.php
+++ b/src/RequestHandler/DataHandler.php
@@ -2,11 +2,10 @@
 
 namespace lav45\MockServer\RequestHandler;
 
-use Amp\Http\Server\Request;
-use Amp\Http\Server\RequestHandler;
 use Amp\Http\Server\Response;
 use lav45\MockServer\EnvParser;
 use lav45\MockServer\Mock\Response\Data;
+use lav45\MockServer\Request\WrappedRequest;
 use lav45\MockServer\RequestHelper;
 use Yiisoft\Data\Paginator\OffsetPaginator;
 use Yiisoft\Data\Paginator\PaginatorException;
@@ -16,7 +15,7 @@ use Yiisoft\Data\Reader\Iterable\IterableDataReader;
  * Class DataHandler
  * @package lav45\MockServer\RequestHandler
  */
-class DataHandler implements RequestHandler
+class DataHandler extends BaseRequestHandler
 {
     /**
      * @param Data $data
@@ -30,11 +29,11 @@ class DataHandler implements RequestHandler
     }
 
     /**
-     * @param Request $request
+     * @param WrappedRequest $request
      * @return Response
      * @throws \JsonException
      */
-    public function handleRequest(Request $request): Response
+    public function handleWrappedRequest(WrappedRequest $request): Response
     {
         $helper = new RequestHelper($request);
         $pagination = $this->data->getPagination();

--- a/src/RequestHandler/WrappedRequestHandlerInterface.php
+++ b/src/RequestHandler/WrappedRequestHandlerInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace lav45\MockServer\RequestHandler;
+
+use Amp\Http\Server\Response;
+use lav45\MockServer\Request\WrappedRequest;
+
+interface WrappedRequestHandlerInterface
+{
+    public function handleWrappedRequest(WrappedRequest $request): Response;
+}

--- a/src/Server.php
+++ b/src/Server.php
@@ -34,8 +34,10 @@ class Server
         $logHandler = new StreamHandler(ByteStream\getStdout());
         $logHandler->pushProcessor(new PsrLogMessageProcessor());
         $logHandler->setFormatter(new ConsoleFormatter(
-            format: "[%datetime%] %level_name%:\t%message%\r\n",
-            dateFormat: 'd.m.Y H:i:s'
+            format: "[%datetime%]\t%level_name%\t%message%\t%context%\n",
+            dateFormat: 'd.m.Y H:i:s.v',
+            allowInlineLineBreaks: true,
+            ignoreEmptyContextAndExtra: true
         ));
 
         $logger = new Logger('mock-server');

--- a/src/middlewares/BaseMiddleware.php
+++ b/src/middlewares/BaseMiddleware.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace lav45\MockServer\middlewares;
+
+use Amp\Http\Server\Middleware;
+use Amp\Http\Server\Request;
+use Amp\Http\Server\RequestHandler;
+use Amp\Http\Server\Response;
+use lav45\MockServer\Request\WrappedRequest;
+
+abstract class BaseMiddleware implements Middleware, WrappedRequestMiddlewareInterface
+{
+    public function handleRequest(Request $request, RequestHandler $requestHandler): Response
+    {
+        $wrappedRequest = WrappedRequest::getInstance($request);
+        return $this->handleWrappedRequest($wrappedRequest, $requestHandler);
+    }
+}

--- a/src/middlewares/RequestParamsMiddleware.php
+++ b/src/middlewares/RequestParamsMiddleware.php
@@ -2,18 +2,21 @@
 
 namespace lav45\MockServer\middlewares;
 
-use Amp\Http\Server\Middleware;
-use Amp\Http\Server\Request;
+use Amp\ByteStream\BufferException;
+use Amp\ByteStream\StreamException;
+use Amp\Http\Server\ClientException;
 use Amp\Http\Server\RequestHandler;
 use Amp\Http\Server\Response;
 use lav45\MockServer\EnvParser;
+use lav45\MockServer\Request\WrappedRequest;
+use lav45\MockServer\RequestHandler\WrappedRequestHandlerInterface;
 use lav45\MockServer\RequestHelper;
 
 /**
  * Class RequestParamsMiddleware
  * @package lav45\MockServer\middlewares
  */
-class RequestParamsMiddleware implements Middleware
+class RequestParamsMiddleware extends BaseMiddleware
 {
     /**
      * @param EnvParser $parser
@@ -22,7 +25,15 @@ class RequestParamsMiddleware implements Middleware
     {
     }
 
-    public function handleRequest(Request $request, RequestHandler $requestHandler): Response
+    /**
+     * @param WrappedRequest $request
+     * @param RequestHandler $requestHandler
+     * @return Response
+     * @throws BufferException
+     * @throws StreamException
+     * @throws ClientException
+     */
+    public function handleWrappedRequest(WrappedRequest $request, RequestHandler $requestHandler): Response
     {
         $helper = new RequestHelper($request);
         $this->parser->addData([
@@ -32,6 +43,9 @@ class RequestParamsMiddleware implements Middleware
                 'urlParams' => $helper->getUrlParams()
             ]
         ]);
-        return $requestHandler->handleRequest($request);
+        if ($requestHandler instanceof WrappedRequestHandlerInterface) {
+            return $requestHandler->handleWrappedRequest($request);
+        }
+        return $requestHandler->handleRequest($request->getRequest());
     }
 }

--- a/src/middlewares/WrappedRequestMiddlewareInterface.php
+++ b/src/middlewares/WrappedRequestMiddlewareInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace lav45\MockServer\middlewares;
+
+use Amp\Http\Server\RequestHandler;
+use Amp\Http\Server\Response;
+use lav45\MockServer\Request\WrappedRequest;
+
+interface WrappedRequestMiddlewareInterface
+{
+    public function handleWrappedRequest(WrappedRequest $request, RequestHandler $requestHandler): Response;
+}


### PR DESCRIPTION
Fixes exceptions `Can't buffer() a payload more than once`, thus allowing proxy a POST request.
Changes list:
- A request wrapper class was added;
- Request wrapper is used both in RequestHandler and Middleware classes;
- Improved logging.