### PR TITLE
Fix pagination

### DIFF
--- a/src/RequestHandler/DataHandler.php
+++ b/src/RequestHandler/DataHandler.php
@@ -24,6 +24,7 @@ class DataHandler extends BaseRequestHandler
         $pagination = $this->data->getPagination();
         $pageSize = (int)$request->get($pagination->pageSizeParam, $pagination->defaultPageSize);
         $currentPage = (int)$request->get($pagination->pageParam, 1);
+        $currentPage = max($currentPage, 1);
 
         $dataReader = new IterableDataReader($this->data->getJson());
         $dataProvider = (new OffsetPaginator($dataReader))


### PR DESCRIPTION
Fix pagination: if the requested page is less than 1, return the first page instead of error 500.